### PR TITLE
add vector masking in read_raster

### DIFF
--- a/pysheds/grid.py
+++ b/pysheds/grid.py
@@ -307,7 +307,7 @@ class Grid(object):
                 mask = rasterio.features.geometry_mask(mask_geometry, shape, affine, invert=True)
                 if not mask.any():  # no mask was applied if all False, out of bounds
                     warnings.warn('mask_geometry does not fall within the bounds of the raster!')
-                    mask = ~mask  # return mask to all True and deliver warning???
+                    mask = ~mask  # return mask to all True and deliver warning
             nodata = f.nodatavals[0]
         if nodata is not None:
             nodata = data.dtype.type(nodata)

--- a/pysheds/grid.py
+++ b/pysheds/grid.py
@@ -305,6 +305,9 @@ class Grid(object):
                 shape = data.shape
             if mask_geometry:
                 mask = rasterio.features.geometry_mask(mask_geometry, shape, affine, invert=True)
+                if not mask.any():  # no mask was applied if all False, out of bounds
+                    warnings.warn('mask_geometry does not fall within the bounds of the raster!')
+                    mask = ~mask  # return mask to all True and deliver warning???
             nodata = f.nodatavals[0]
         if nodata is not None:
             nodata = data.dtype.type(nodata)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -215,15 +215,11 @@ def test_windowed_reading():
 
 def test_mask_geometry():
     grid = Grid.from_raster(dem_path,'dem', mask_geometry=feature_geometry)
-#    this was my first attempt at the test, but I thought below was cleaner?
-#    rows = np.array([225, 226, 227, 228, 229, 230, 231, 232] * 7)
-#    cols = np.array([np.arange(98,105)] * 8).T.reshape(1,56)
-#    masked_cols, masked_rows = grid.mask.nonzero()
-#    assert (masked_cols == cols).all()
-#    assert (masked_rows == rows).all()
-    true_count = np.count_nonzero(grid.mask)
-    assert true_count == 56, "number of True cells in mask is incorrect"
-    assert (np.size(grid.mask) - true_count) == 131697, "mask is incorrect"
+    rows = np.array([225, 226, 227, 228, 229, 230, 231, 232] * 7)
+    cols = np.array([np.arange(98,105)] * 8).T.reshape(1,56)
+    masked_cols, masked_rows = grid.mask.nonzero()
+    assert (masked_cols == cols).all()
+    assert (masked_rows == rows).all()
     with warnings.catch_warnings(record=True) as warn:
         warnings.simplefilter("always")
         grid = Grid.from_raster(dem_path,'dem', mask_geometry=out_of_bounds)


### PR DESCRIPTION
Hey Matt, I've been playing around with getting the `catchment` method to clip to a vector geometry and had this idea for setting a mask on the `Raster` to use in conjunction w/ the `apply_mask` attr.
I'm not sure if this is the best way to go about doing this, but it has worked with what I'm doing. Let me know if you think this might be a good direction to go in or if there is a better place to try to implement something like this. Seems like we'd have to get the geometry mask figured out at read in so we can handle it with rasterio, otherwise, I think it might be  a lot tougher.

Thanks!