### PR TITLE
Fix for bincount type touchyness

### DIFF
--- a/pysheds/grid.py
+++ b/pysheds/grid.py
@@ -1255,7 +1255,7 @@ class Grid(object):
             invalid_entries = fdir.flat[invalid_cells]
             fdir.flat[invalid_cells] = 0
             # Ensure consistent types
-            fdir = fdir.astype(mintype)
+            fdir = fdir.astype('int32')
             # Set nodata cells to zero
             fdir[nodata_cells] = 0
             # Get matching of start and end nodes


### PR DESCRIPTION
np.bincount has at some point become extremely selective about its input type, accepting only 'int32' and nothing else.