### PR TITLE
Type checking of nodata values

### DIFF
--- a/pysheds/sview.py
+++ b/pysheds/sview.py
@@ -82,7 +82,7 @@ class Raster(np.ndarray):
         except:
             raise TypeError('`object` and `flexible` dtypes not allowed.')
         try:
-            assert np.min_scalar_type(viewfinder.nodata) <= obj.dtype
+            assert np.can_cast(viewfinder.nodata, obj.dtype, casting='safe')
         except:
             raise TypeError('`nodata` value not representable in dtype of array.')
         # Don't allow original viewfinder and metadata to be modified
@@ -288,7 +288,7 @@ class MultiRaster(Raster):
         except:
             raise TypeError('`object` and `flexible` dtypes not allowed.')
         try:
-            assert np.min_scalar_type(viewfinder.nodata) <= obj.dtype
+            assert np.can_cast(viewfinder.nodata, obj.dtype, casting='safe')
         except:
             raise TypeError('`nodata` value not representable in dtype of array.')
         # Don't allow original viewfinder and metadata to be modified


### PR DESCRIPTION
This pull request replaces the call to `np.min_scalar_type` with `np.can_cast` in the nodata check that occurs when creating a Raster or MultiRaster. 

Currently, the use of `np.min_scalar_type` causes this check to fail unexpectedly in a few cases. For example, try creating an int8 raster with a nodata value of 0:
```
import numpy as np
from pysheds.sview import ViewFinder, Raster

values = np.arange(100, dtype='int8').reshape(10,10)
view = ViewFinder(shape=values.shape, nodata=0)
raster = Raster(values, view)
```
Even though 0 is representable in int8, this code results in the following error:
```
TypeError: `nodata` value not representable in dtype of array.
```

This occurs because `np.min_scalar_type(0)` returns uint8, which is not <= int8. Replacing this with `np.can_cast` instead checks that the nodata value is representable in the raster's dtype, which I believe is the intended behavior.