### PR TITLE
Bugfixes for D8 routing.

### DIFF
--- a/pysheds/_sgrid.py
+++ b/pysheds/_sgrid.py
@@ -10,7 +10,7 @@ from numba.types import float64, int64, uint32, uint16, uint8, boolean, UniTuple
       parallel=True,
       cache=True)
 def _d8_flowdir_numba(dem, dx, dy, dirmap, nodata_cells, nodata_out, flat=-1, pit=-2):
-    fdir = np.zeros(dem.shape, dtype=np.int64)
+    fdir = np.full(dem.shape, nodata_out, dtype=np.int64)
     m, n = dem.shape
     dd = np.sqrt(dx**2 + dy**2)
     row_offsets = np.array([-1, -1, 0, 1, 1, 1, 0, -1])
@@ -18,9 +18,7 @@ def _d8_flowdir_numba(dem, dx, dy, dirmap, nodata_cells, nodata_out, flat=-1, pi
     distances = np.array([dy, dd, dx, dd, dy, dd, dx, dd])
     for i in prange(1, m - 1):
         for j in prange(1, n - 1):
-            if nodata_cells[i, j]:
-                fdir[i, j] = nodata_out
-            else:
+            if not nodata_cells[i, j]:
                 elev = dem[i, j]
                 max_slope = -np.inf
                 for k in range(8):

--- a/pysheds/_sgrid.py
+++ b/pysheds/_sgrid.py
@@ -24,6 +24,9 @@ def _d8_flowdir_numba(dem, dx, dy, dirmap, nodata_cells, nodata_out, flat=-1, pi
                 for k in range(8):
                     row_offset = row_offsets[k]
                     col_offset = col_offsets[k]
+                    if nodata_cells[i + row_offset, j + col_offset]:
+                        # this neighbor is nodata, skip
+                        continue
                     distance = distances[k]
                     slope = (elev - dem[i + row_offset, j + col_offset]) / distance
                     if slope > max_slope:


### PR DESCRIPTION
This PR addresses two issues with `_d8_flowdir_numba`.

1. The returned flowdir array was incorrect for nonzero values of nodata_out. The loops start with pixel at index (1, 1), which means there was always a border of zeros in the returned array. This is solved by simply initializing the array to the nodata_out value at the beginning before filling the array.
2. Nodata cells were improperly considered when they were adjacent to a valid cell. The solution is the skip any cell neighbors that are also nodata cells. This prevents the possibility of flow being incorrectly routed because of the nodata value.