### PR TITLE
Add capability to run with Python 3.12

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/pysheds/pgrid.py
+++ b/pysheds/pgrid.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import geojson
 from affine import Affine
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 try:
     import scipy.sparse
     import scipy.spatial

--- a/pysheds/pview.py
+++ b/pysheds/pview.py
@@ -3,7 +3,7 @@ from scipy import spatial
 from scipy import interpolate
 import pyproj
 from affine import Affine
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 
 _OLD_PYPROJ = LooseVersion(pyproj.__version__) < LooseVersion('2.2')
 _pyproj_init = '+init=epsg:4326' if _OLD_PYPROJ else 'epsg:4326'

--- a/pysheds/sview.py
+++ b/pysheds/sview.py
@@ -2,7 +2,7 @@ import copy
 import numpy as np
 from . import projection
 from affine import Affine
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 try:
     import scipy.spatial
     _HAS_SCIPY = True

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering :: GIS",
         "Topic :: Scientific/Engineering :: Hydrology",
     ],
@@ -33,6 +34,7 @@ setup(
     install_requires=[
         "affine",
         "geojson",
+        "looseversion",
         "numba",
         "numpy",
         "pandas",


### PR DESCRIPTION
Python's built-in [distutils](https://docs.python.org/3.11/distutils/) module was [removed in Python 3.12](https://docs.python.org/3/whatsnew/3.12.html).  Pysheds used `distutils.LooseVersion` to check pyproj versions.  This PR uses [looseversion](https://github.com/effigies/looseversion) as a drop-in replacement for this functionality, adding compatibility with Python 3.12 and minimizing potential disruption to use with older Python versions.

This PR also adds Python 3.12 to the CI run matrix, ensuring that compatibility with Python 3.12 will be preserved.