### PR TITLE
Use Priority Flood algorithm to fill depressions

### DIFF
--- a/pysheds/_sgrid.py
+++ b/pysheds/_sgrid.py
@@ -1919,7 +1919,7 @@ def count(start=0, step=1):
         yield n
         n += step
 
-@njit
+@njit(cache=True)
 def _priority_flood(dem, dem_mask, tuple_type):
     open_cells = typedlist.List.empty_list(tuple_type)  # Priority queue
     pits = typedlist.List.empty_list(tuple_type)  # FIFO queue

--- a/pysheds/sgrid.py
+++ b/pysheds/sgrid.py
@@ -6,9 +6,11 @@ import numpy as np
 import pandas as pd
 import geojson
 from affine import Affine
+from numba.types import Tuple, int64
+from numba import from_dtype
+
 try:
     import skimage.measure
-    import skimage.morphology
     _HAS_SKIMAGE = True
 except ModuleNotFoundError:
     _HAS_SKIMAGE = False
@@ -2113,8 +2115,6 @@ class sGrid():
         depressions : Raster
                       Boolean Raster indicating locations of depressions.
         """
-        if not _HAS_SKIMAGE:
-            raise ImportError('detect_depressions requires skimage.morphology module')
         input_overrides = {'dtype' : np.float64, 'nodata' : dem.nodata}
         kwargs.update(input_overrides)
         dem = self._input_handler(dem, **kwargs)
@@ -2148,23 +2148,11 @@ class sGrid():
                       Raster representing digital elevation data with multi-celled
                       depressions removed.
         """
-        if not _HAS_SKIMAGE:
-            raise ImportError('resolve_flats requires skimage.morphology module')
-        input_overrides = {'dtype' : np.float64, 'nodata' : dem.nodata}
-        kwargs.update(input_overrides)
-        dem = self._input_handler(dem, **kwargs)
+        # Implementation detail of priority flood algorithm.
+        tuple_type = Tuple([from_dtype(dem.dtype), int64, int64])
         dem_mask = self._get_nodata_cells(dem)
-        dem_mask[0, :] = True
-        dem_mask[-1, :] = True
-        dem_mask[:, 0] = True
-        dem_mask[:, -1] = True
-        # Make sure nothing flows to the nodata cells
-        seed = np.copy(dem)
-        seed[~dem_mask] = np.nanmax(dem)
-        dem_out = skimage.morphology.reconstruction(seed, dem, method='erosion')
-        dem_out = self._output_handler(data=dem_out, viewfinder=dem.viewfinder,
-                                     metadata=dem.metadata, nodata=nodata_out)
-        return dem_out
+        return _self._priority_flood(dem, dem_mask, tuple_type)
+
 
     def detect_flats(self, dem, **kwargs):
         """

--- a/pysheds/sgrid.py
+++ b/pysheds/sgrid.py
@@ -2148,11 +2148,13 @@ class sGrid():
                       Raster representing digital elevation data with multi-celled
                       depressions removed.
         """
-        # Implementation detail of priority flood algorithm.
-        tuple_type = Tuple([from_dtype(dem.dtype), int64, int64])
         dem_mask = self._get_nodata_cells(dem)
-        return _self._priority_flood(dem, dem_mask, tuple_type)
-
+        result = _self._priority_flood(dem, dem_mask)
+        dem_filled = self._output_handler(data=result,
+                                        viewfinder=dem.viewfinder,
+                                        metadata=dem.metadata,
+                                        nodata=dem.nodata)
+        return dem_filled
 
     def detect_flats(self, dem, **kwargs):
         """


### PR DESCRIPTION
Fixes #239 

Runtime is about 7.5min on a (12150, 9622) float32 raster which is acceptable.

This variant of the algorithm (as presented in the paper linked in the issue) uses a plain queue to avoid some of the overhead of using the priority queue. Since numba doesn't have a plain queue, I use a list that gets flushed periodically.
A critical part of making this fast was using numba's typedlist which still seems to be experimental according to the docs.

I'm open to feedback.