### PR TITLE
Use bool_ instead of bool8 (deprecated).

### DIFF
--- a/pysheds/_sgrid.py
+++ b/pysheds/_sgrid.py
@@ -313,7 +313,7 @@ def _d8_catchment_recursion(ix, catch, fdir, offsets, r_dirmap):
 @njit(boolean[:,:](int64[:,:], UniTuple(int64, 2), UniTuple(int64, 8)),
       cache=True)
 def _d8_catchment_recur_numba(fdir, pour_point, dirmap):
-    catch = np.zeros(fdir.shape, dtype=np.bool8)
+    catch = np.zeros(fdir.shape, dtype=np.bool_)
     offset = fdir.shape[1]
     i, j = pour_point
     ix = (i * offset) + j
@@ -327,7 +327,7 @@ def _d8_catchment_recur_numba(fdir, pour_point, dirmap):
 
 @njit(boolean[:,:](int64[:,:], UniTuple(int64, 2), UniTuple(int64, 8)))
 def _d8_catchment_iter_numba(fdir, pour_point, dirmap):
-    catch = np.zeros(fdir.shape, dtype=np.bool8)
+    catch = np.zeros(fdir.shape, dtype=np.bool_)
     offset = fdir.shape[1]
     i, j = pour_point
     ix = (i * offset) + j
@@ -370,7 +370,7 @@ def _dinf_catchment_recursion(ix, catch, fdir_0, fdir_1, offsets, r_dirmap):
 @njit(boolean[:,:](int64[:,:], int64[:,:], UniTuple(int64, 2), UniTuple(int64, 8)),
       cache=True)
 def _dinf_catchment_recur_numba(fdir_0, fdir_1, pour_point, dirmap):
-    catch = np.zeros(fdir_0.shape, dtype=np.bool8)
+    catch = np.zeros(fdir_0.shape, dtype=np.bool_)
     dirmap = np.array(dirmap)
     offset = fdir_0.shape[1]
     i, j = pour_point
@@ -387,7 +387,7 @@ def _dinf_catchment_recur_numba(fdir_0, fdir_1, pour_point, dirmap):
 @njit(boolean[:,:](int64[:,:], int64[:,:], UniTuple(int64, 2), UniTuple(int64, 8)),
       cache=True)
 def _dinf_catchment_iter_numba(fdir_0, fdir_1, pour_point, dirmap):
-    catch = np.zeros(fdir_0.shape, dtype=np.bool8)
+    catch = np.zeros(fdir_0.shape, dtype=np.bool_)
     dirmap = np.array(dirmap)
     offset = fdir_0.shape[1]
     i, j = pour_point
@@ -421,7 +421,7 @@ def _dinf_catchment_iter_numba(fdir_0, fdir_1, pour_point, dirmap):
 def _mfd_catchment_iter_numba(fdir, pour_point):
     _, m, n = fdir.shape
     mn = m * n
-    catch = np.zeros((m, n), dtype=np.bool8)
+    catch = np.zeros((m, n), dtype=np.bool_)
     i, j = pour_point
     ix = (i * n) + j
     offsets = np.array([-n, 1 - n, 1,
@@ -542,7 +542,7 @@ def _dinf_accumulation_recursion(startnode, endnode, acc, fdir_0, fdir_1,
 def _dinf_accumulation_recur_numba(acc, fdir_0, fdir_1, indegree, startnodes,
                                    props_0, props_1):
     n = startnodes.size
-    visited = np.zeros(acc.shape, dtype=np.bool8)
+    visited = np.zeros(acc.shape, dtype=np.bool_)
     for k in range(n):
         startnode = startnodes.flat[k]
         endnode_0 = fdir_0.flat[startnode]
@@ -611,7 +611,7 @@ def _dinf_accumulation_eff_recursion(startnode, endnode, acc, fdir_0, fdir_1,
 def _dinf_accumulation_eff_numba(acc, fdir_0, fdir_1, indegree, startnodes,
                                  props_0, props_1, eff):
     n = startnodes.size
-    visited = np.zeros(acc.shape, dtype=np.bool8)
+    visited = np.zeros(acc.shape, dtype=np.bool_)
     for k in range(n):
         startnode = startnodes.flat[k]
         endnode_0 = fdir_0.flat[startnode]
@@ -742,7 +742,7 @@ def _d8_flow_distance_recursion(ix, fdir, visits, dist, weights, r_dirmap,
 @njit(float64[:,:](int64[:,:], float64[:,:], UniTuple(int64, 2), UniTuple(int64, 8)),
       cache=True)
 def _d8_flow_distance_recur_numba(fdir, weights, pour_point, dirmap):
-    visits = np.zeros(fdir.shape, dtype=np.bool8)
+    visits = np.zeros(fdir.shape, dtype=np.bool_)
     dist = np.full(fdir.shape, np.inf, dtype=np.float64)
     r_dirmap = np.array([dirmap[4], dirmap[5], dirmap[6],
                          dirmap[7], dirmap[0], dirmap[1],
@@ -760,7 +760,7 @@ def _d8_flow_distance_recur_numba(fdir, weights, pour_point, dirmap):
 @njit(float64[:,:](int64[:,:], float64[:,:], UniTuple(int64, 2), UniTuple(int64, 8)),
       cache=True)
 def _d8_flow_distance_iter_numba(fdir, weights, pour_point, dirmap):
-    visits = np.zeros(fdir.shape, dtype=np.bool8)
+    visits = np.zeros(fdir.shape, dtype=np.bool_)
     dist = np.full(fdir.shape, np.inf, dtype=np.float64)
     r_dirmap = np.array([dirmap[4], dirmap[5], dirmap[6],
                          dirmap[7], dirmap[0], dirmap[1],
@@ -818,7 +818,7 @@ def _dinf_flow_distance_recursion(ix, fdir_0, fdir_1, visits, dist,
       cache=True)
 def _dinf_flow_distance_recur_numba(fdir_0, fdir_1, weights_0, weights_1,
                               pour_point, dirmap):
-    visits = np.zeros(fdir_0.shape, dtype=np.bool8)
+    visits = np.zeros(fdir_0.shape, dtype=np.bool_)
     dist = np.full(fdir_0.shape, np.inf, dtype=np.float64)
     r_dirmap = np.array([dirmap[4], dirmap[5], dirmap[6],
                          dirmap[7], dirmap[0], dirmap[1],
@@ -839,7 +839,7 @@ def _dinf_flow_distance_recur_numba(fdir_0, fdir_1, weights_0, weights_1,
 def _dinf_flow_distance_iter_numba(fdir_0, fdir_1, weights_0, weights_1,
                                    pour_point, dirmap):
     dist = np.full(fdir_0.shape, np.inf, dtype=np.float64)
-    visited = np.zeros(fdir_0.shape, dtype=np.bool8)
+    visited = np.zeros(fdir_0.shape, dtype=np.bool_)
     r_dirmap = np.array([dirmap[4], dirmap[5], dirmap[6],
                          dirmap[7], dirmap[0], dirmap[1],
                          dirmap[2], dirmap[3]])
@@ -883,7 +883,7 @@ def _mfd_flow_distance_iter_numba(fdir, pour_point, weights):
     _, m, n = fdir.shape
     mn = m * n
     dist = np.full((m, n), np.inf, dtype=np.float64)
-    visited = np.zeros((m, n), dtype=np.bool8)
+    visited = np.zeros((m, n), dtype=np.bool_)
     i, j = pour_point
     ix = (i * n) + j
     offsets = np.array([-n, 1 - n, 1,
@@ -1020,9 +1020,9 @@ def _mfd_reverse_distance_iter_numba(rdist, fdir, indegree, startnodes, weights)
 def _par_get_candidates_numba(dem, inside):
     n = inside.size
     offset = dem.shape[1]
-    fdirs_defined = np.zeros(dem.shape, dtype=np.bool8)
-    flats = np.zeros(dem.shape, dtype=np.bool8)
-    higher_cells = np.zeros(dem.shape, dtype=np.bool8)
+    fdirs_defined = np.zeros(dem.shape, dtype=np.bool_)
+    flats = np.zeros(dem.shape, dtype=np.bool_)
+    higher_cells = np.zeros(dem.shape, dtype=np.bool_)
     offsets = np.array([-offset, 1 - offset, 1,
                         1 + offset, offset, - 1 + offset,
                         - 1, - 1 - offset])
@@ -1656,7 +1656,7 @@ def _dinf_fix_cycles_recursion(node, fdir_0, fdir_1, ancestor,
       cache=True)
 def _dinf_fix_cycles_numba(fdir_0, fdir_1, max_cycle_size):
     n = fdir_0.size
-    visited = np.zeros(fdir_0.shape, dtype=np.bool8)
+    visited = np.zeros(fdir_0.shape, dtype=np.bool_)
     depth = 0
     for node in range(n):
         _dinf_fix_cycles_recursion(node, fdir_0, fdir_1, node,
@@ -1820,7 +1820,7 @@ def _construct_matching(fdir, dirmap):
 def _find_pits_numba(dem, inside):
     n = inside.size
     offset = dem.shape[1]
-    pits = np.zeros(dem.shape, dtype=np.bool8)
+    pits = np.zeros(dem.shape, dtype=np.bool_)
     offsets = np.array([-offset, 1 - offset, 1,
                         1 + offset, offset, - 1 + offset,
                         - 1, - 1 - offset])

--- a/pysheds/sgrid.py
+++ b/pysheds/sgrid.py
@@ -706,7 +706,7 @@ class sGrid():
         -------
         catch : Raster
                 Raster indicating cells that lie in the catchment. The dtype will be
-                np.bool8, unless `pour_value` is specified, in which case the dtype will
+                np.bool_, unless `pour_value` is specified, in which case the dtype will
                 be the smallest dtype capable of representing the pour value.
         """
         if routing.lower() == 'd8':
@@ -1282,7 +1282,7 @@ class sGrid():
         else:
             raise ValueError('Routing method must be one of: `d8`, `dinf`, `mfd`')
         dem_overrides = {'dtype' : np.float64, 'nodata' : dem.nodata}
-        mask_overrides = {'dtype' : np.bool8, 'nodata' : False}
+        mask_overrides = {'dtype' : np.bool_, 'nodata' : False}
         kwargs.update(fdir_overrides)
         fdir = self._input_handler(fdir, **kwargs)
         kwargs.update(dem_overrides)
@@ -1412,7 +1412,7 @@ class sGrid():
             fdir_overrides = {'dtype' : np.int64, 'nodata' : fdir.nodata}
         else:
             raise NotImplementedError('Only implemented for `d8` routing.')
-        mask_overrides = {'dtype' : np.bool8, 'nodata' : False}
+        mask_overrides = {'dtype' : np.bool_, 'nodata' : False}
         kwargs.update(fdir_overrides)
         fdir = self._input_handler(fdir, **kwargs)
         kwargs.update(mask_overrides)
@@ -1495,7 +1495,7 @@ class sGrid():
             fdir_overrides = {'dtype' : np.int64, 'nodata' : fdir.nodata}
         else:
             raise NotImplementedError('Only implemented for `d8` routing.')
-        mask_overrides = {'dtype' : np.bool8, 'nodata' : False}
+        mask_overrides = {'dtype' : np.bool_, 'nodata' : False}
         kwargs.update(fdir_overrides)
         fdir = self._input_handler(fdir, **kwargs)
         kwargs.update(mask_overrides)
@@ -1559,7 +1559,7 @@ class sGrid():
             fdir_overrides = {'dtype' : np.int64, 'nodata' : fdir.nodata}
         else:
             raise NotImplementedError('Only implemented for `d8` routing.')
-        mask_overrides = {'dtype' : np.bool8, 'nodata' : False}
+        mask_overrides = {'dtype' : np.bool_, 'nodata' : False}
         kwargs.update(fdir_overrides)
         fdir = self._input_handler(fdir, **kwargs)
         kwargs.update(mask_overrides)
@@ -2119,7 +2119,7 @@ class sGrid():
         kwargs.update(input_overrides)
         dem = self._input_handler(dem, **kwargs)
         filled_dem = self.fill_depressions(dem, **kwargs)
-        depressions = np.zeros(filled_dem.shape, dtype=np.bool8)
+        depressions = np.zeros(filled_dem.shape, dtype=np.bool_)
         depressions[dem != filled_dem] = True
         depressions[np.isnan(dem) | np.isnan(filled_dem)] = False
         depressions = self._output_handler(data=depressions,
@@ -2382,7 +2382,7 @@ class sGrid():
             assert isinstance(mask, Raster)
         except:
             raise TypeError('`mask` must be a Raster instance.')
-        mask_overrides = {'dtype' : np.bool8, 'nodata' : False}
+        mask_overrides = {'dtype' : np.bool_, 'nodata' : False}
         kwargs.update(mask_overrides)
         mask = self._input_handler(mask, **kwargs)
         affine = mask.affine
@@ -2416,9 +2416,9 @@ class sGrid():
             raise TypeError('Data must be a Raster.')
         nodata = data.nodata
         if np.isnan(nodata):
-            nodata_cells = np.isnan(data).astype(np.bool8)
+            nodata_cells = np.isnan(data).astype(np.bool_)
         else:
-            nodata_cells = (data == nodata).astype(np.bool8)
+            nodata_cells = (data == nodata).astype(np.bool_)
         return nodata_cells
 
     def _pop_rim(self, data, nodata=0):

--- a/pysheds/sview.py
+++ b/pysheds/sview.py
@@ -334,7 +334,7 @@ class ViewFinder():
         self.crs = crs
         self.nodata = nodata
         if mask is None:
-            self.mask = np.ones(shape, dtype=np.bool8)
+            self.mask = np.ones(shape, dtype=np.bool_)
         else:
             self.mask = mask
 
@@ -385,10 +385,10 @@ class ViewFinder():
     @mask.setter
     def mask(self, new_mask):
         try:
-            assert (np.min_scalar_type(new_mask) <= np.dtype(np.bool8))
+            assert (np.min_scalar_type(new_mask) <= np.dtype(np.bool_))
         except:
             raise TypeError('`mask` must be of boolean type')
-        new_mask = np.asarray(new_mask).astype(np.bool8)
+        new_mask = np.asarray(new_mask).astype(np.bool_)
         self._mask = new_mask
 
     @property
@@ -621,7 +621,7 @@ class View():
         k, m, n = data.shape
         if out is None:
             out = np.empty((k, *target_view.shape), dtype=dtype)
-        out_mask = np.ones((k, *target_view.shape), dtype=np.bool8)
+        out_mask = np.ones((k, *target_view.shape), dtype=np.bool_)
         for i in range(k):
             slice_viewfinder = ViewFinder(affine=data_view.affine, mask=data_view.mask[i],
                                           nodata=data_view.nodata, crs=data_view.crs)
@@ -971,4 +971,3 @@ class View():
         else:
             raise ValueError('Interpolation method must be one of: `nearest`, `linear`')
         return view
-


### PR DESCRIPTION
Fixes deprecation warnings from numpy when using pysheds.

```
DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)
```