### PR TITLE
add missing minlength to np.bincount

### DIFF
--- a/pysheds/sgrid.py
+++ b/pysheds/sgrid.py
@@ -1576,7 +1576,7 @@ class sGrid():
         masked_fdir = np.where(mask, fdir, 0).astype(np.int64)
         startnodes = np.arange(fdir.size, dtype=np.int64)
         endnodes = _self._flatten_fdir_numba(masked_fdir, dirmap).reshape(fdir.shape)
-        indegree = np.bincount(endnodes.ravel()).astype(np.uint8)
+        indegree = np.bincount(endnodes.ravel(), minlength=fdir.size).astype(np.uint8)
         orig_indegree = np.copy(indegree)
         startnodes = startnodes[(indegree == 0)]
         min_order = np.full(fdir.shape, np.iinfo(np.int64).max, dtype=np.int64)
@@ -1672,7 +1672,7 @@ class sGrid():
             weights = (~nodata_cells).reshape(fdir.shape).astype(np.float64)
         startnodes = np.arange(fdir.size, dtype=np.int64)
         endnodes = _self._flatten_fdir_numba(fdir, dirmap).reshape(fdir.shape)
-        indegree = np.bincount(endnodes.ravel()).astype(np.uint8)
+        indegree = np.bincount(endnodes.ravel(), minlength=fdir.size).astype(np.uint8)
         startnodes = startnodes[(indegree == 0)]
         rdist = np.zeros(fdir.shape, dtype=np.float64)
         if algorithm.lower() == 'iterative':


### PR DESCRIPTION
# Summary
This merge request fixes a missing `minlength` argument in two calls to `np.bincount`

# Motivation
Currently, the `distance_to_ridge` method will sometimes fail unexpectedly with an IndexError. For example, here's an error trace I receive when attempting to run the method in northern Colorado:
```
  File "...\pfdf\watershed.py", line 318, in relief   
    relief = grid.distance_to_ridge(
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "...\pysheds\sgrid.py", line 1649, in distance_to_ridge
    rdist = self._d8_distance_to_ridge(fdir=fdir, weights=weights,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...\pysheds\sgrid.py", line 1676, in _d8_distance_to_ridge
    startnodes = startnodes[(indegree == 0)]
                 ~~~~~~~~~~^^^^^^^^^^^^^^^^^
IndexError: boolean index did not match indexed array along axis 0; size of axis is 6205794 but size of corresponding boolean axis is 6205763
```
This issue occurs when there are NoData values along the bottom edge of the flow direction raster. Essentially, the maximum value in the `endnodes` array is less than the size of the fdir array, and so the subsequent call to `np.bincount` returns an index array with fewer elements than the `startnodes` array.

This pull request fixes the bug by adding the `minlength` option to `np.bincount` (as is done elsewhere in `sgrid.py`) to ensure that the index array always has the correct number of elements.