### PR TITLE
fix nodata type checking following numpy 2+

### DIFF
--- a/pysheds/sview.py
+++ b/pysheds/sview.py
@@ -81,10 +81,8 @@ class Raster(np.ndarray):
             assert not np.issubdtype(obj.dtype, np.flexible)
         except:
             raise TypeError('`object` and `flexible` dtypes not allowed.')
-        try:
-            assert np.can_cast(viewfinder.nodata, obj.dtype, casting='safe')
-        except:
-            raise TypeError('`nodata` value not representable in dtype of array.')
+        cls._validate_nodata(viewfinder.nodata, obj.dtype)
+            
         # Don't allow original viewfinder and metadata to be modified
         viewfinder = viewfinder.copy()
         metadata = metadata.copy()
@@ -116,6 +114,16 @@ class Raster(np.ndarray):
                                         inherit_metadata=False,
                                         new_metadata=metadata)
         return input_array, viewfinder, metadata
+
+    @staticmethod
+    def _validate_nodata(nodata, dtype):
+        "Checks the NoData value is preserved when cast to the raster dtype"
+        nodata = np.array(nodata)
+        casted = nodata.astype(dtype, casting='unsafe')
+        try:
+            assert (nodata == casted) or np.can_cast(nodata, dtype, casting='safe')
+        except:
+            raise TypeError('`nodata` value not representable in dtype of array.')
 
     @property
     def viewfinder(self):
@@ -287,10 +295,7 @@ class MultiRaster(Raster):
             assert not np.issubdtype(obj.dtype, np.flexible)
         except:
             raise TypeError('`object` and `flexible` dtypes not allowed.')
-        try:
-            assert np.can_cast(viewfinder.nodata, obj.dtype, casting='safe')
-        except:
-            raise TypeError('`nodata` value not representable in dtype of array.')
+        cls._validate_nodata(viewfinder.nodata, obj.dtype)
         # Don't allow original viewfinder and metadata to be modified
         viewfinder = viewfinder.copy()
         metadata = metadata.copy()


### PR DESCRIPTION
# Summary
This pull request makes NoData type checking compatible with numpy 2+

# Details
Currently, most of the package fails upon a fresh install. This is because the Raster class uses `numpy.can_cast` to type check NoData values, but the function's [API changed](https://numpy.org/devdocs/release/2.0.0-notes.html#np-can-cast-cannot-be-called-on-python-int-float-or-complex) following the release of numpy 2.0.

As an example, try running the following code:
```
import numpy as np
from pysheds.sview import ViewFinder, Raster

values = np.arange(100, dtype='int8').reshape(10,10)
view = ViewFinder(shape=values.shape, nodata=0)
raster = Raster(values, view)
```
This should work fine, but if you are using numpy 2+, it instead results in the error:
```
Traceback (most recent call last):
  File "...\pysheds\sview.py", line 85, in __new__
    assert np.can_cast(viewfinder.nodata, obj.dtype, casting='safe')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can_cast() does not support Python ints, floats, and complex because the result used to depend on the value.
This change was part of adopting NEP 50, we may explicitly allow them again in the future.       

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "...\pysheds\sview.py", line 87, in __new__
    raise TypeError('`nodata` value not representable in dtype of array.')
TypeError: `nodata` value not representable in dtype of array.
```
This pull request addresses this issue by updating the NoData type checking logic such that it should be compatible with both numpy 1 and 2.