### PR TITLE
Fix nodata type checking for can cast with numpy >2 by putting the nodata in the correct type

### DIFF
--- a/pysheds/pgrid.py
+++ b/pysheds/pgrid.py
@@ -110,7 +110,7 @@ class Grid(object):
         props = {
             'affine' : Affine(1.,0.,0.,0.,1.,0.),
             'shape' : (1,1),
-            'nodata' : 0,
+            'nodata' : np.int64(0),
             'crs' : pyproj.Proj(_pyproj_init),
         }
         return props

--- a/pysheds/pgrid.py
+++ b/pysheds/pgrid.py
@@ -1034,8 +1034,8 @@ class Grid(object):
             fdir_0.flat[prop_0 == 0] = fdir_1.flat[prop_0 == 0]
             fdir_1.flat[prop_1 == 0] = fdir_0.flat[prop_1 == 0]
             # Set nodata cells to zero
-            fdir_0[invalid_cells] = 0
-            fdir_1[invalid_cells] = 0
+            fdir_0[invalid_cells] = np.int64(0)
+            fdir_1[invalid_cells] = np.int64(0)
             # Create indexing arrays for convenience
             domain = np.arange(fdir.size, dtype=np.min_scalar_type(fdir.size))
             unique = np.zeros(fdir.size, dtype=np.bool)
@@ -1251,11 +1251,11 @@ class Grid(object):
                     nodata_cells = (fdir == nodata_in)
             invalid_cells = ~np.in1d(fdir.ravel(), dirmap)
             invalid_entries = fdir.flat[invalid_cells]
-            fdir.flat[invalid_cells] = 0
+            fdir.flat[invalid_cells] = np.int64(0)
             # Ensure consistent types
             fdir = fdir.astype(mintype)
             # Set nodata cells to zero
-            fdir[nodata_cells] = 0
+            fdir[nodata_cells] = np.int64(0)
             # Get matching of start and end nodes
             startnodes, endnodes = self._construct_matching(fdir, domain,
                                                             dirmap=dirmap)
@@ -1805,8 +1805,8 @@ class Grid(object):
                 fdir_0.flat[prop_0 == 0] = fdir_1.flat[prop_0 == 0]
                 fdir_1.flat[prop_1 == 0] = fdir_0.flat[prop_1 == 0]
                 # Set nodata cells to zero
-                fdir_0[invalid_cells] = 0
-                fdir_1[invalid_cells] = 0
+                fdir_0[invalid_cells] = np.int64(0)
+                fdir_1[invalid_cells] = np.int64(0)
                 # Create indexing arrays for convenience
                 visited = np.zeros(fdir.size, dtype=np.bool)
                 # nvisited = np.zeros(fdir.size, dtype=int)

--- a/pysheds/pgrid.py
+++ b/pysheds/pgrid.py
@@ -698,7 +698,7 @@ class Grid(object):
                 dem_mask = np.where(dem.ravel() == nodata_in)[0]
         if routing.lower() == 'd8':
             if nodata_out is None:
-                nodata_out = 0
+                nodata_out = np.int64(0)
             return self._d8_flowdir(dem=dem, dem_mask=dem_mask, out_name=out_name,
                                     nodata_in=nodata_in, nodata_out=nodata_out, pits=pits,
                                     flats=flats, dirmap=dirmap, inplace=inplace, as_crs=as_crs,

--- a/pysheds/sgrid.py
+++ b/pysheds/sgrid.py
@@ -1414,7 +1414,7 @@ class sGrid():
             fdir_overrides = {'dtype' : np.int64, 'nodata' : fdir.nodata}
         else:
             raise NotImplementedError('Only implemented for `d8` routing.')
-        mask_overrides = {'dtype' : np.bool_, 'nodata' : False}
+        mask_overrides = {'dtype' : np.bool_, 'nodata' : np.bool_(False)}
         kwargs.update(fdir_overrides)
         fdir = self._input_handler(fdir, **kwargs)
         kwargs.update(mask_overrides)
@@ -1561,7 +1561,7 @@ class sGrid():
             fdir_overrides = {'dtype' : np.int64, 'nodata' : fdir.nodata}
         else:
             raise NotImplementedError('Only implemented for `d8` routing.')
-        mask_overrides = {'dtype' : np.bool_, 'nodata' : False}
+        mask_overrides = {'dtype' : np.bool_, 'nodata' : np.bool_(False)}
         kwargs.update(fdir_overrides)
         fdir = self._input_handler(fdir, **kwargs)
         kwargs.update(mask_overrides)

--- a/pysheds/sgrid.py
+++ b/pysheds/sgrid.py
@@ -599,7 +599,7 @@ class sGrid():
         nodata_cells = self._get_nodata_cells(dem)
         if routing.lower() == 'd8':
             if nodata_out is None:
-                nodata_out = 0
+                nodata_out = np.int64(0)
             fdir = self._d8_flowdir(dem=dem, nodata_cells=nodata_cells,
                                     nodata_out=nodata_out, flats=flats,
                                     pits=pits, dirmap=dirmap)
@@ -660,7 +660,7 @@ class sGrid():
                                     mask=new_mask)
 
     def catchment(self, x, y, fdir, pour_value=None, dirmap=(64, 128, 1, 2, 4, 8, 16, 32),
-                  nodata_out=False, xytype='coordinate', routing='d8', snap='corner',
+                  nodata_out=np.bool_(False), xytype='coordinate', routing='d8', snap='corner',
                   algorithm='iterative', **kwargs):
         """
         Delineates a watershed from a given pour point (x, y).
@@ -819,7 +819,7 @@ class sGrid():
         return catch
 
     def accumulation(self, fdir, weights=None, dirmap=(64, 128, 1, 2, 4, 8, 16, 32),
-                     nodata_out=0., efficiency=None, routing='d8', cycle_size=1,
+                     nodata_out=np.float64(0.), efficiency=None, routing='d8', cycle_size=1,
                      algorithm='iterative', **kwargs):
         """
         Generates a flow accumulation raster. If no weights are provided, the value of each cell
@@ -1526,7 +1526,7 @@ class sGrid():
         return profiles, connections
 
     def stream_order(self, fdir, mask, dirmap=(64, 128, 1, 2, 4, 8, 16, 32),
-                     nodata_out=0, routing='d8', algorithm='iterative', **kwargs):
+                     nodata_out=np.int64(0), routing='d8', algorithm='iterative', **kwargs):
         """
         Computes the Strahler stream order.
 

--- a/pysheds/sgrid.py
+++ b/pysheds/sgrid.py
@@ -1284,7 +1284,7 @@ class sGrid():
         else:
             raise ValueError('Routing method must be one of: `d8`, `dinf`, `mfd`')
         dem_overrides = {'dtype' : np.float64, 'nodata' : dem.nodata}
-        mask_overrides = {'dtype' : np.bool_, 'nodata' : False}
+        mask_overrides = {'dtype' : np.bool_, 'nodata' : np.bool_(False)}
         kwargs.update(fdir_overrides)
         fdir = self._input_handler(fdir, **kwargs)
         kwargs.update(dem_overrides)
@@ -1335,7 +1335,7 @@ class sGrid():
         else:
             raise ValueError('Algorithm must be `iterative` or `recursive`.')
         hand = self._output_handler(data=hand, viewfinder=fdir.viewfinder,
-                                    metadata=fdir.metadata, nodata=-1)
+                                    metadata=fdir.metadata, nodata=np.int64(-1))
         return hand
 
     def _dinf_compute_hand(self, fdir, mask, dirmap=(64, 128, 1, 2, 4, 8, 16, 32),
@@ -1357,7 +1357,7 @@ class sGrid():
         else:
             raise ValueError('Algorithm must be `iterative` or `recursive`.')
         hand = self._output_handler(data=hand, viewfinder=fdir.viewfinder,
-                                    metadata=fdir.metadata, nodata=-1)
+                                    metadata=fdir.metadata, nodata=np.int64(-1))
         return hand
 
     def _mfd_compute_hand(self, fdir, mask, dirmap=(64, 128, 1, 2, 4, 8, 16, 32),
@@ -1375,7 +1375,7 @@ class sGrid():
             raise ValueError('Algorithm must be `iterative` or `recursive`.')
         new_mask = fdir.mask[0]
         hand = self._output_handler(data=hand, viewfinder=fdir.viewfinder,
-                                    metadata=fdir.metadata, nodata=-1,
+                                    metadata=fdir.metadata, nodata=np.int64(-1),
                                     mask=new_mask)
         return hand
 
@@ -1425,7 +1425,7 @@ class sGrid():
         # Set nodata cells to zero
         fdir[nodata_cells] = np.int64(0)
         fdir[invalid_cells] = np.int64(0)
-        maskleft, maskright, masktop, maskbottom = self._pop_rim(mask, nodata=False)
+        maskleft, maskright, masktop, maskbottom = self._pop_rim(mask, nodata=np.bool_(False))
         masked_fdir = np.where(mask, fdir, 0).astype(np.int64)
         startnodes = np.arange(fdir.size, dtype=np.int64)
         endnodes = _self._flatten_fdir_numba(masked_fdir, dirmap).reshape(fdir.shape)
@@ -1497,7 +1497,7 @@ class sGrid():
             fdir_overrides = {'dtype' : np.int64, 'nodata' : fdir.nodata}
         else:
             raise NotImplementedError('Only implemented for `d8` routing.')
-        mask_overrides = {'dtype' : np.bool_, 'nodata' : False}
+        mask_overrides = {'dtype' : np.bool_, 'nodata' : np.bool_(False)}
         kwargs.update(fdir_overrides)
         fdir = self._input_handler(fdir, **kwargs)
         kwargs.update(mask_overrides)
@@ -2051,7 +2051,7 @@ class sGrid():
         # Find pits
         pits = _self._find_pits_numba(dem, inside)
         pits = self._output_handler(data=pits, viewfinder=dem.viewfinder,
-                                    metadata=dem.metadata, nodata=False)
+                                    metadata=dem.metadata, nodata=np.bool_(False))
         return pits
 
     def fill_pits(self, dem, nodata_out=None, **kwargs):
@@ -2125,7 +2125,7 @@ class sGrid():
         depressions = self._output_handler(data=depressions,
                                            viewfinder=filled_dem.viewfinder,
                                            metadata=filled_dem.metadata,
-                                           nodata=False)
+                                           nodata=np.bool_(False))
         return depressions
 
     def fill_depressions(self, dem, nodata_out=np.nan, **kwargs):
@@ -2184,7 +2184,7 @@ class sGrid():
         # handle nodata values in dem
         flats, _, _ = _self._par_get_candidates_numba(dem, inside)
         flats = self._output_handler(data=flats, viewfinder=dem.viewfinder,
-                                     metadata=dem.metadata, nodata=False)
+                                     metadata=dem.metadata, nodata=np.bool_(False))
         return flats
 
     def resolve_flats(self, dem, nodata_out=None, eps=1e-5, max_iter=1000, **kwargs):
@@ -2372,7 +2372,7 @@ class sGrid():
             assert isinstance(mask, Raster)
         except:
             raise TypeError('`mask` must be a Raster instance.')
-        mask_overrides = {'dtype' : np.bool_, 'nodata' : False}
+        mask_overrides = {'dtype' : np.bool_, 'nodata' : np.bool_(False)}
         kwargs.update(mask_overrides)
         mask = self._input_handler(mask, **kwargs)
         affine = mask.affine

--- a/pysheds/sgrid.py
+++ b/pysheds/sgrid.py
@@ -129,7 +129,7 @@ class sGrid():
         props = {
             'affine' : Affine(1.,0.,0.,0.,1.,0.),
             'shape' : (1,1),
-            'nodata' : 0,
+            'nodata' : np.int64(0),
             'crs' : projection.init(),
         }
         return props

--- a/pysheds/sgrid.py
+++ b/pysheds/sgrid.py
@@ -903,8 +903,8 @@ class sGrid():
         nodata_cells = self._get_nodata_cells(fdir)
         invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
-        fdir[nodata_cells] = 0
-        fdir[invalid_cells] = 0
+        fdir[nodata_cells] = np.int64(0)
+        fdir[invalid_cells] = np.int64(0)
         # Start and end nodes
         startnodes = np.arange(fdir.size, dtype=np.int64)
         endnodes = _self._flatten_fdir_numba(fdir, dirmap).reshape(fdir.shape)
@@ -1007,7 +1007,7 @@ class sGrid():
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
         # Set nodata cells to zero
-        fdir[nodata_cells] = 0.
+        fdir[nodata_cells] = np.int64(0).
         # Start and end nodes
         startnodes = np.arange(fdir[0].size, dtype=np.int64)
         props = fdir
@@ -1151,8 +1151,8 @@ class sGrid():
         nodata_cells = self._get_nodata_cells(fdir)
         invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
-        fdir[nodata_cells] = 0
-        fdir[invalid_cells] = 0
+        fdir[nodata_cells] = np.int64(0)
+        fdir[invalid_cells] = np.int64(0)
         if xytype in {'label', 'coordinate'}:
             x, y = self.nearest_cell(x, y, fdir.affine, snap)
         # TODO: Should this be ones for all cells?
@@ -1324,8 +1324,8 @@ class sGrid():
         nodata_cells = self._get_nodata_cells(fdir)
         invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
-        fdir[nodata_cells] = 0
-        fdir[invalid_cells] = 0
+        fdir[nodata_cells] = np.int64(0)
+        fdir[invalid_cells] = np.int64(0)
         dirleft, dirright, dirtop, dirbottom = self._pop_rim(fdir, nodata=0)
         maskleft, maskright, masktop, maskbottom = self._pop_rim(mask, nodata=False)
         if algorithm.lower() == 'iterative':
@@ -1423,8 +1423,8 @@ class sGrid():
         nodata_cells = self._get_nodata_cells(fdir)
         invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
-        fdir[nodata_cells] = 0
-        fdir[invalid_cells] = 0
+        fdir[nodata_cells] = np.int64(0)
+        fdir[invalid_cells] = np.int64(0)
         maskleft, maskright, masktop, maskbottom = self._pop_rim(mask, nodata=False)
         masked_fdir = np.where(mask, fdir, 0).astype(np.int64)
         startnodes = np.arange(fdir.size, dtype=np.int64)
@@ -1506,8 +1506,8 @@ class sGrid():
         nodata_cells = self._get_nodata_cells(fdir)
         invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
-        fdir[nodata_cells] = 0
-        fdir[invalid_cells] = 0
+        fdir[nodata_cells] = np.int64(0)
+        fdir[invalid_cells] = np.int64(0)
         maskleft, maskright, masktop, maskbottom = self._pop_rim(mask, nodata=False)
         masked_fdir = np.where(mask, fdir, 0).astype(np.int64)
         startnodes = np.arange(fdir.size, dtype=np.int64)
@@ -1570,8 +1570,8 @@ class sGrid():
         nodata_cells = self._get_nodata_cells(fdir)
         invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
-        fdir[nodata_cells] = 0
-        fdir[invalid_cells] = 0
+        fdir[nodata_cells] = np.int64(0)
+        fdir[invalid_cells] = np.int64(0)
         maskleft, maskright, masktop, maskbottom = self._pop_rim(mask, nodata=False)
         masked_fdir = np.where(mask, fdir, 0).astype(np.int64)
         startnodes = np.arange(fdir.size, dtype=np.int64)
@@ -1665,8 +1665,8 @@ class sGrid():
         nodata_cells = self._get_nodata_cells(fdir)
         invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
-        fdir[nodata_cells] = 0
-        fdir[invalid_cells] = 0
+        fdir[nodata_cells] = np.int64(0)
+        fdir[invalid_cells] = np.int64(0)
         # TODO: Should this be ones for all cells?
         if weights is None:
             weights = (~nodata_cells).reshape(fdir.shape).astype(np.float64)
@@ -1733,7 +1733,7 @@ class sGrid():
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
         # Set nodata cells to zero
-        fdir[nodata_cells] = 0.
+        fdir[nodata_cells] = np.int64(0).
         # Start and end nodes
         startnodes = np.arange(fdir[0].size, dtype=np.int64)
         props = fdir
@@ -1820,8 +1820,8 @@ class sGrid():
         nodata_cells = self._get_nodata_cells(fdir)
         invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
-        fdir[nodata_cells] = 0
-        fdir[invalid_cells] = 0
+        fdir[nodata_cells] = np.int64(0)
+        fdir[invalid_cells] = np.int64(0)
         dirleft, dirright, dirtop, dirbottom = self._pop_rim(fdir, nodata=0)
         startnodes = np.arange(fdir.size, dtype=np.int64).reshape(fdir.shape)
         endnodes = _self._flatten_fdir_numba(fdir, dirmap).reshape(fdir.shape)
@@ -1854,7 +1854,7 @@ class sGrid():
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
         # Set nodata cells to zero
-        fdir[nodata_cells] = 0.
+        fdir[nodata_cells] = np.int64(0).
         # Start and end nodes
         startnodes = np.arange(fdir[0].size, dtype=np.int64).reshape(fdir[0].shape)
         props = fdir
@@ -1922,8 +1922,8 @@ class sGrid():
         nodata_cells = self._get_nodata_cells(fdir)
         invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
-        fdir[nodata_cells] = 0
-        fdir[invalid_cells] = 0
+        fdir[nodata_cells] = np.int64(0)
+        fdir[invalid_cells] = np.int64(0)
         dx = abs(fdir.affine.a)
         dy = abs(fdir.affine.e)
         cdist = _self._d8_cell_distances_numba(fdir, dirmap, dx, dy)
@@ -1955,7 +1955,7 @@ class sGrid():
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
         # Set nodata cells to zero
-        fdir[nodata_cells] = 0.
+        fdir[nodata_cells] = np.int64(0).
         # Start and end nodes
         startnodes = np.arange(fdir[0].size, dtype=np.int64).reshape(fdir[0].shape)
         props = fdir

--- a/pysheds/sgrid.py
+++ b/pysheds/sgrid.py
@@ -1294,7 +1294,7 @@ class sGrid():
         # Set default nodata for hand index and hand
         if nodata_out is None:
             if return_index:
-                nodata_out = -1
+                nodata_out = np.int64(-1)
             else:
                 nodata_out = np.nan
         # Compute height above nearest drainage

--- a/pysheds/sgrid.py
+++ b/pysheds/sgrid.py
@@ -1007,7 +1007,7 @@ class sGrid():
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
         # Set nodata cells to zero
-        fdir[nodata_cells] = np.int64(0).
+        fdir[nodata_cells] = np.int64(0)
         # Start and end nodes
         startnodes = np.arange(fdir[0].size, dtype=np.int64)
         props = fdir
@@ -1733,7 +1733,7 @@ class sGrid():
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
         # Set nodata cells to zero
-        fdir[nodata_cells] = np.int64(0).
+        fdir[nodata_cells] = np.int64(0)
         # Start and end nodes
         startnodes = np.arange(fdir[0].size, dtype=np.int64)
         props = fdir
@@ -1854,7 +1854,7 @@ class sGrid():
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
         # Set nodata cells to zero
-        fdir[nodata_cells] = np.int64(0).
+        fdir[nodata_cells] = np.int64(0)
         # Start and end nodes
         startnodes = np.arange(fdir[0].size, dtype=np.int64).reshape(fdir[0].shape)
         props = fdir
@@ -1955,7 +1955,7 @@ class sGrid():
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
         # Set nodata cells to zero
-        fdir[nodata_cells] = np.int64(0).
+        fdir[nodata_cells] = np.int64(0)
         # Start and end nodes
         startnodes = np.arange(fdir[0].size, dtype=np.int64).reshape(fdir[0].shape)
         props = fdir

--- a/pysheds/sview.py
+++ b/pysheds/sview.py
@@ -82,6 +82,7 @@ class Raster(np.ndarray):
         except:
             raise TypeError('`object` and `flexible` dtypes not allowed.')
         try:
+            nodata = np.array(viewfinder.nodata, dtype=obj.dtype)
             assert np.can_cast(viewfinder.nodata, obj.dtype, casting='safe')
         except:
             raise TypeError('`nodata` value not representable in dtype of array.')
@@ -288,6 +289,7 @@ class MultiRaster(Raster):
         except:
             raise TypeError('`object` and `flexible` dtypes not allowed.')
         try:
+            nodata = np.array(viewfinder.nodata, dtype=obj.dtype)
             assert np.can_cast(viewfinder.nodata, obj.dtype, casting='safe')
         except:
             raise TypeError('`nodata` value not representable in dtype of array.')

--- a/pysheds/sview.py
+++ b/pysheds/sview.py
@@ -83,7 +83,7 @@ class Raster(np.ndarray):
             raise TypeError('`object` and `flexible` dtypes not allowed.')
         try:
             nodata = np.array(viewfinder.nodata, dtype=obj.dtype)
-            assert np.can_cast(viewfinder.nodata, obj.dtype, casting='safe')
+            assert np.can_cast(nodata, obj.dtype, casting='safe')
         except:
             raise TypeError('`nodata` value not representable in dtype of array.')
         # Don't allow original viewfinder and metadata to be modified
@@ -290,7 +290,7 @@ class MultiRaster(Raster):
             raise TypeError('`object` and `flexible` dtypes not allowed.')
         try:
             nodata = np.array(viewfinder.nodata, dtype=obj.dtype)
-            assert np.can_cast(viewfinder.nodata, obj.dtype, casting='safe')
+            assert np.can_cast(nodata, obj.dtype, casting='safe')
         except:
             raise TypeError('`nodata` value not representable in dtype of array.')
         # Don't allow original viewfinder and metadata to be modified

--- a/pysheds/sview.py
+++ b/pysheds/sview.py
@@ -82,8 +82,7 @@ class Raster(np.ndarray):
         except:
             raise TypeError('`object` and `flexible` dtypes not allowed.')
         try:
-            nodata = np.array(viewfinder.nodata, dtype=obj.dtype)
-            assert np.can_cast(nodata, obj.dtype, casting='safe')
+            assert np.can_cast(viewfinder.nodata, obj.dtype, casting='safe')
         except:
             raise TypeError('`nodata` value not representable in dtype of array.')
         # Don't allow original viewfinder and metadata to be modified
@@ -289,8 +288,7 @@ class MultiRaster(Raster):
         except:
             raise TypeError('`object` and `flexible` dtypes not allowed.')
         try:
-            nodata = np.array(viewfinder.nodata, dtype=obj.dtype)
-            assert np.can_cast(nodata, obj.dtype, casting='safe')
+            assert np.can_cast(viewfinder.nodata, obj.dtype, casting='safe')
         except:
             raise TypeError('`nodata` value not representable in dtype of array.')
         # Don't allow original viewfinder and metadata to be modified


### PR DESCRIPTION
All nodata was put into a numpy type. This builds on the work of @joelrahman.