### PR TITLE
Fix: Handle NumPy 2.0 removal of np.in1d

### DIFF
--- a/pysheds/sgrid.py
+++ b/pysheds/sgrid.py
@@ -9,6 +9,10 @@ from affine import Affine
 from numba.types import Tuple, int64
 from numba import from_dtype
 
+# solving numpy 2.x compabilities
+# Handle NumPy 2.0 deprecation of in1d
+_isin = getattr(np, 'isin', None) or getattr(np, 'in1d')
+
 try:
     import skimage.measure
     _HAS_SKIMAGE = True
@@ -901,7 +905,7 @@ class sGrid():
                          nodata_out=0., efficiency=None, algorithm='iterative', **kwargs):
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
-        invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
+        invalid_cells = ~_isin(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
         fdir[nodata_cells] = 0
         fdir[invalid_cells] = 0
@@ -1149,7 +1153,7 @@ class sGrid():
                           snap='corner', algorithm='iterative', **kwargs):
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
-        invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
+        invalid_cells = ~_isin(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
         fdir[nodata_cells] = 0
         fdir[invalid_cells] = 0
@@ -1322,7 +1326,7 @@ class sGrid():
                          nodata_out=-1, algorithm='iterative'):
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
-        invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
+        invalid_cells = ~_isin(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
         fdir[nodata_cells] = 0
         fdir[invalid_cells] = 0
@@ -1421,7 +1425,7 @@ class sGrid():
         mask = self._input_handler(mask, **kwargs)
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
-        invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
+        invalid_cells = ~_isin(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
         fdir[nodata_cells] = 0
         fdir[invalid_cells] = 0
@@ -1504,7 +1508,7 @@ class sGrid():
         mask = self._input_handler(mask, **kwargs)
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
-        invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
+        invalid_cells = ~_isin(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
         fdir[nodata_cells] = 0
         fdir[invalid_cells] = 0
@@ -1568,7 +1572,7 @@ class sGrid():
         mask = self._input_handler(mask, **kwargs)
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
-        invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
+        invalid_cells = ~_isin(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
         fdir[nodata_cells] = 0
         fdir[invalid_cells] = 0
@@ -1663,7 +1667,7 @@ class sGrid():
                               algorithm='iterative', nodata_out=np.nan, **kwargs):
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
-        invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
+        invalid_cells = ~_isin(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
         fdir[nodata_cells] = 0
         fdir[invalid_cells] = 0
@@ -1818,7 +1822,7 @@ class sGrid():
                     nodata_out=np.nan):
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
-        invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
+        invalid_cells = ~_isin(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
         fdir[nodata_cells] = 0
         fdir[invalid_cells] = 0
@@ -1920,7 +1924,7 @@ class sGrid():
                            nodata_out=np.nan):
         # Find nodata cells and invalid cells
         nodata_cells = self._get_nodata_cells(fdir)
-        invalid_cells = ~np.in1d(fdir.ravel(), dirmap).reshape(fdir.shape)
+        invalid_cells = ~_isin(fdir.ravel(), dirmap).reshape(fdir.shape)
         # Set nodata cells to zero
         fdir[nodata_cells] = 0
         fdir[invalid_cells] = 0


### PR DESCRIPTION
Description:
This PR addresses the AttributeError caused by the removal of np.in1d in NumPy 2.0.

Changes:

Added a compatibility alias _isin using getattr(np, 'isin', np.in1d) to support both legacy and modern NumPy versions. It could be solved by changing the Numpy version, but as there's the poll for maybe adding UV and others this works as temporary solution to use pysheds.

Testing:
I verified that it worked with the acc and D8 functions in a current project that I'm working on.